### PR TITLE
Corrige erro quando `searchTerm` não está presente

### DIFF
--- a/components/Scraper.js
+++ b/components/Scraper.js
@@ -26,7 +26,7 @@ const scraper = async (url) => {
     nextPage = 0
 
     let searchTerm = new URL(url)
-    searchTerm = searchTerm.searchParams.get('q')
+    searchTerm = searchTerm.searchParams.get('q') || ''
 
     const notify = termAlreadySearched(searchTerm, 1)
 
@@ -63,7 +63,7 @@ const scrapePage = async ($, searchTerm, notify) => {
         for( let i = 0; i < adList.length; i++ ){
 
             log.debug( 'Checking ad: ' + (i+1))
-        
+
             const advert    = adList[i]
             const title     = advert.subject
             const id        = advert.listId
@@ -78,7 +78,7 @@ const scrapePage = async ($, searchTerm, notify) => {
                 price,
                 notify
             }
-            
+
             const ad = new Ad( result )
             await ad.process()
 
@@ -89,7 +89,7 @@ const scrapePage = async ($, searchTerm, notify) => {
                 sumPrices += ad.price
             }
         }
-        
+
         log.info( 'Valid ads: ' + validAds )
 
         if (validAds) {


### PR DESCRIPTION
Também tive o mesmo problema dessa issue: https://github.com/carmolim/olx-monitor/issues/6

Essa correção simples faz com que o erro não ocorra mais e que o usuário possa utilizar uma URL sem termo de busca específico, apenas filtros.