### PR TITLE
[bug] allowing to use urls without a searchTerm

### DIFF
--- a/components/Ad.js
+++ b/components/Ad.js
@@ -13,6 +13,7 @@ class Ad{
         this.url              = ad.url
         this.title            = ad.title
         this.searchTerm       = ad.searchTerm
+        this.searchId         = ad.searchId
         this.price            = ad.price
         this.valid            = false
         this.saved            = null,
@@ -105,7 +106,6 @@ class Ad{
             }
         }
     }
-
 
     // some elements found in the ads selection don't have an url
     // I supposed that OLX adds other content between the ads,

--- a/database/database.js
+++ b/database/database.js
@@ -10,6 +10,7 @@ const createTables = async () => {
     const query = `
         CREATE TABLE IF NOT EXISTS "ads" (
             "id"            INTEGER NOT NULL UNIQUE,
+            "searchId"      TEXT NOT NULL,
             "searchTerm"    TEXT NOT NULL,
             "title"	        TEXT NOT NULL,
             "price"         INTEGER NOT NULL,

--- a/repositories/adRepositorie.js
+++ b/repositories/adRepositorie.js
@@ -53,12 +53,37 @@ const getAdsBySearchTerm = async (term, limit) => {
 }
 
 
+const getAdsBySearchId = async (id, limit) => {
+    log.debug( 'adRepositorie: getAd' )
+
+    const query = `SELECT * FROM ads WHERE searchId = ? LIMIT ?`
+    const values = [id, limit]
+
+    return new Promise(function(resolve, reject){
+        db.all(query, values, function(error, rows){
+
+            if(error){
+                reject(error)
+                return
+            }
+
+            if(!rows){
+                reject('No ad with this id was found')
+                return
+            }
+
+            resolve(rows)
+        })
+    })
+}
+
+
 const createAd = async (ad) => {
     log.debug( 'adRepositorie: createAd' )
 
     const query = `
-        INSERT INTO ads( id, url, title, searchTerm, price, created, lastUpdate )
-        VALUES( ?, ?, ?, ?, ?, ?, ? )
+        INSERT INTO ads( id, url, title, searchTerm, searchId, price, created, lastUpdate )
+        VALUES( ?, ?, ?, ?, ?, ?, ?, ? )
     `
 
     const now = new Date().getTime()
@@ -68,6 +93,7 @@ const createAd = async (ad) => {
         ad.url,
         ad.title,
         ad.searchTerm,
+        ad.searchId,
         ad.price, 
         now,
         now
@@ -108,6 +134,7 @@ const updateAd = async (ad) => {
 module.exports = {
     getAd,
     getAdsBySearchTerm,
+    getAdsBySearchId,
     createAd,
     updateAd
 }


### PR DESCRIPTION
essa PR resolve o issue https://github.com/carmolim/olx-monitor/issues/6

Ao invés de utilizar o `searchTerm` para verifica já foi feita uma consulta anteriormente agora é criado um hash simples com base na url para esse fim, que é salvo no sqlite na coluna `searchId`. 

É necessário deletar o banco de dados e deixar a tabela ser criada novamente para funcionar como o esperado.