### PR TITLE
feat: agrupar anúncios por telegramID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.js
 *.db
 *.sqlite
 node_modules
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scrapper.log
 config.js
 *.db
 *.sqlite
+node_modules

--- a/components/Ad.js
+++ b/components/Ad.js
@@ -16,6 +16,7 @@ class Ad {
         this.valid      = false
         this.saved      = null,
         this.notify     = ad.notify
+        this.chatID     = ad.chatID
     }
 
     process = async () => {
@@ -65,7 +66,7 @@ class Ad {
         if (this.notify) {
             try {
                 const msg = 'New ad found!\n' + this.title + ' - R$' + this.price + '\n\n' + this.url
-                notifier.sendNotification(msg, this.id)
+                notifier.sendNotification(msg, this.id, this.chatID)
             } catch (error) {
                 $logger.error('Could not send a notification')
             }
@@ -98,7 +99,7 @@ class Ad {
                 const msg = 'Price drop found! ' + decreasePercentage + '% OFF!\n' +
                     'From R$' + this.saved.price + ' to R$' + this.price + '\n\n' + this.url
 
-                await notifier.sendNotification(msg, this.id)
+                await notifier.sendNotification(msg, this.id, this.chatID)
             }
         }
     }

--- a/components/Notifier.js
+++ b/components/Notifier.js
@@ -3,8 +3,8 @@
 const config = require('../config');
 const axios = require('axios');
 
-exports.sendNotification = async (msg) => {
-    const apiUrl = `https://api.telegram.org/bot${config.telegramToken}/sendMessage?chat_id=${config.telegramChatID}&text=`;
+exports.sendNotification = async (msg, id, chatID) => {
+    const apiUrl = `https://api.telegram.org/bot${config.telegramToken}/sendMessage?chat_id=${chatID}&text=`;
     const encodedMsg = encodeURIComponent(msg);
     return await axios.get(apiUrl + encodedMsg, { timeout: 5000 });
 };

--- a/components/Scraper.js
+++ b/components/Scraper.js
@@ -13,7 +13,7 @@ let validAds = 0
 let adsFound = 0
 let nextPage = true
 
-const scraper = async (url) => {
+const scraper = async (url, chatID) => {
     page = 1
     maxPrice = 0
     minPrice = 99999999
@@ -25,7 +25,6 @@ const scraper = async (url) => {
     const parsedUrl = new URL(url)
     const searchTerm = parsedUrl.searchParams.get('q') || ''
     const notify = await urlAlreadySearched(url)
-    $logger.info(`Will notify: ${notify}`)
 
     do {
         currentUrl = setUrlParam(url, 'o', page)
@@ -33,7 +32,7 @@ const scraper = async (url) => {
         try {
             response        = await $httpClient(currentUrl)
             const $         = cheerio.load(response)
-            nextPage        = await scrapePage($, searchTerm, notify, url)
+            nextPage        = await scrapePage($, searchTerm, notify, chatID)
         } catch (error) {
             $logger.error(error)
             return
@@ -63,7 +62,7 @@ const scraper = async (url) => {
     }
 }
 
-const scrapePage = async ($, searchTerm, notify) => {
+const scrapePage = async ($, searchTerm, notify, chatID) => {
     try {
         const script = $('script[id="__NEXT_DATA__"]').text()
         const adList = JSON.parse(script).props.pageProps.ads
@@ -93,7 +92,8 @@ const scrapePage = async ($, searchTerm, notify) => {
                 title,
                 searchTerm,
                 price,
-                notify
+                notify,
+                chatID
             }
 
             const ad = new Ad(result)
@@ -118,7 +118,6 @@ const urlAlreadySearched = async (url) => {
     try {
         const ad = await scraperRepository.getLogsByUrl(url, 1)
         if (ad.length) {
-            $logger.info('Will notify')
             return true
         }
         $logger.info('First run, no notifications')

--- a/example.env
+++ b/example.env
@@ -1,3 +1,2 @@
 #Telegram 
 TELEGRAM_TOKEN = 
-TELEGRAM_CHAT_ID =

--- a/index.js
+++ b/index.js
@@ -6,11 +6,19 @@ const { scraper } = require('./components/Scraper')
 const { createTables } = require('./database/database.js')
 
 const runScraper = () => {
-    for (let i = 0; i < config.urls.length; i++) {
-        try {
-            scraper(config.urls[i])
-        } catch (error) {
-            $logger.error(error)
+
+    for (var chatID in config.urls) {
+        if (config.urls.hasOwnProperty(chatID)) {
+            var urlsArray = config.urls[chatID];
+    
+            // Percorrendo todas as URLs dentro do array
+            for (var i = 0; i < urlsArray.length; i++) {
+                try {
+                    scraper(urlsArray[i], chatID)
+                } catch (error) {
+                    $logger.error(error)
+                }
+            }
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Vi nessa situação uma oportunidade para aprender um pouco sobre scrapping usan
 
 ## Instalação e configuração
 
-Para utilizar esse script você precisa ter o `node` e o `npm` devidamente instalados, ter uma conta no [Telegram](https://telegram.org/), e idealmente um computador que fique ligado 27/7 para executar o script continuamente. Eu usei um Raspberry Pi 2 que consome pouca energia e já uso para outros fins, mas você pode usar um VPS, ou um sevidor gratuito da Oracle.
+Para utilizar esse script você precisa ter o `node` e o `npm` devidamente instalados, ter uma conta no [Telegram](https://telegram.org/), e idealmente um computador que fique ligado 24/7 para executar o script continuamente. Eu usei um Raspberry Pi 2 que consome pouca energia e já uso para outros fins, mas você pode usar um VPS, ou um sevidor gratuito da Oracle.
 
 Se você já está familiarizado com a API do Telegram e já mexeu bom bots segue um passo-a-passo mais enxuto:
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,10 @@ Dentro do repositório tem um arquivo chamado `example.env`, você precisa renom
 | Variável          | Exemplo                                |
 | ----------------- | -------------------------------------- |
 | TELEGRAM_TOKEN    | Token do seu bot gerado pelo BotFather |
-| TELEGRAM_CHAT\_ID | ID do seu chat                         |
+
+Já o CHAT_ID, que é para qual chat o bot enviará os alertas, deve ser configurado no config.js. Você pode separar as URLs por "categorias" e fazer com que o bot envie separadamente os alertas. Muito útil em grupos com tópicos!
+
+Confira o arquivo sample-config.js para mais detalhes e exemplos.
 
 ### O que deve ser monitorado?
 

--- a/sample-config.js
+++ b/sample-config.js
@@ -2,16 +2,34 @@ require('dotenv').config()
 
 let config = {}
 
-config.urls = [
-    'url1',
-    'url2'
-]
+config.urls = {
+    'chatID1': [
+        'url1',
+        'url2',
+    ],
+    'chatID2': [
+        'url1',
+    ]
+}
+
+/* 
+Exemplo (ids ficticios):
+
+config.urls = {
+    '-12981921412': [ // enviará para um grupo
+        'https://www.olx.com.br/informatica/notebooks/estado-sp?pe=500&ps=10&q=notebook&na=1&na=2&na=4&nme=1&nme=3&nme=5',
+        'https://www.olx.com.br/informatica/notebooks/estado-sp/regiao-de-sorocaba?pe=500&ps=10&q=notebook&na=1&na=2&na=4&nme=1&nme=3&nme=5',
+    ],
+    '-12981921412&reply_to_message_id=140': [ // enviará para o mesmo grupo, mas em um tópico (chamado iphones, por exemplo)
+        'https://www.olx.com.br/informatica/notebooks/estado-sp/regiao-de-sorocaba?pe=500&ps=10&q=iphone&na=1&na=2&na=4&nme=1&nme=3&nme=5',
+    ]
+}
+ */
 
 // this tool can help you create the interval string:
 // https://tool.crontap.com/cronjob-debugger
 
 config.interval = '*/5 * * * *' 
-config.telegramChatID = process.env.TELEGRAM_CHAT_ID
 config.telegramToken = process.env.TELEGRAM_TOKEN
 config.dbFile = 'ads.db'
 


### PR DESCRIPTION
Oba! Eu pretendia trabalhar para ser compatível com o modelo anterior antes de fazer o PR, mas vi que a branch mudou completamente, então decidi submeter como está para pegarem a ideia e aplicar, se acharem interessante.

a mudança gira em torno da configuração dos anúncios no arquivo config.js:

```
config.urls = {
    '-12981921412': [ // enviará para um grupo
        'https://www.olx.com.br/informatica/notebooks/estado-sp?pe=500&ps=10&q=notebook&na=1&na=2&na=4&nme=1&nme=3&nme=5',
        'https://www.olx.com.br/informatica/notebooks/estado-sp/regiao-de-sorocaba?pe=500&ps=10&q=notebook&na=1&na=2&na=4&nme=1&nme=3&nme=5',
    ],
    '-12981921412&reply_to_message_id=140': [ // enviará para o mesmo grupo, mas em um tópico diferente (chamado iphones, por exemplo)
        'https://www.olx.com.br/informatica/notebooks/estado-sp/regiao-de-sorocaba?pe=500&ps=10&q=iphone&na=1&na=2&na=4&nme=1&nme=3&nme=5',
    ]
}
```

config.urls passaria a ser um json em vez de um array, onde as chaves são os IDs dos canais que o bot enviará notificações dos anúncios que estão no valor (que é um array).

Estou usando por algum tempo e tem dado tudo certo :)

Obrigado pelo projeto!