### PR TITLE
Fix OLX parsing and serialize Telegram notifications

### DIFF
--- a/src/components/Ad.js
+++ b/src/components/Ad.js
@@ -65,7 +65,7 @@ class Ad {
         if (this.notify) {
             try {
                 const msg = 'New ad found!\n' + this.title + ' - R$' + this.price + '\n\n' + this.url
-                notifier.sendNotification(msg, this.id)
+                await notifier.sendNotification(msg, this.id)
             } catch (error) {
                 $logger.error('Could not send a notification')
             }

--- a/src/components/Scraper.js
+++ b/src/components/Scraper.js
@@ -66,12 +66,17 @@ const scraper = async (url) => {
 const scrapePage = async ($, searchTerm, notify) => {
     try {
         const script = $('script[id="__NEXT_DATA__"]').text()
+        let adList
 
-        if (!script) {
-            return false
+        if (script) {
+            adList = JSON.parse(script).props.pageProps.ads
+        } else {
+            const flightScript = $('script:not([src])').toArray()
+                .map(element => $(element).text())
+                .find(script => script.includes('listId'))
+            const payload = JSON.parse(flightScript.match(/^self\.__next_f\.push\((.*)\)\s*$/s)[1])[1]
+            adList = JSON.parse(payload.match(/"ads":(\[.*\]),"searchBoxProps":/s)[1])
         }
-
-        const adList = JSON.parse(script).props.pageProps.ads
 
         if (!Array.isArray(adList) || !adList.length ) {
             return false
@@ -90,7 +95,8 @@ const scrapePage = async ($, searchTerm, notify) => {
             const title = advert.subject
             const id = advert.listId
             const url = advert.url
-            const price = parseInt(advert.price?.replace('R$ ', '')?.replace('.', '') || '0')
+            const rawPrice = advert.price ?? advert.priceValue ?? '0'
+            const price = parseInt(String(rawPrice).replace(/\D/g, '') || '0')
 
             const result = {
                 id,

--- a/src/components/Scraper.js
+++ b/src/components/Scraper.js
@@ -108,7 +108,7 @@ const scrapePage = async ($, searchTerm, notify) => {
             }
 
             const ad = new Ad(result)
-            ad.process()
+            await ad.process()
 
             if (ad.valid) {
                 validAds++


### PR DESCRIPTION
## Summary
- fall back to the current Next.js flight payload when `__NEXT_DATA__` is absent
- accept the current `priceValue` field while preserving legacy price support
- await each ad processing operation before continuing the scraper loop
- await new-ad Telegram requests so timeouts are handled by the existing `try/catch`

## Validation
- Node syntax checks passed
- controlled tests confirmed `Ad.process()` waits for Telegram and the scraper waits for each ad
- Telegram accepted a real test notification (`message_id=7148`)
- parsed all four configured OLX searches over HTTP 200 during the parsing validation
- extracted 25, 3, 50, and 50 valid ads respectively during the parsing validation